### PR TITLE
inherit from Transform instead of Readable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Readable = require('readable-stream/readable');
+var Transform = require('readable-stream/transform');
 var isReadable = require('is-stream').readable;
 var util = require('util');
 
@@ -55,7 +55,7 @@ function OrderedStreams (streams, options) {
 
   options.objectMode = true;
 
-  Readable.call(this, options);
+  Transform.call(this, options);
 
   if (!Array.isArray(streams)) {
     streams = [streams];
@@ -74,8 +74,11 @@ function OrderedStreams (streams, options) {
     }
   });
 }
-util.inherits(OrderedStreams, Readable);
+util.inherits(OrderedStreams, Transform);
 
-OrderedStreams.prototype._read = function () {};
+OrderedStreams.prototype._transform = function (chunk, enc, cb) {
+  // forward writes
+  cb(null, chunk);
+};
 
 module.exports = OrderedStreams;

--- a/test/main.js
+++ b/test/main.js
@@ -52,6 +52,32 @@ describe('ordered-read-streams', function () {
     s3.end();
   });
 
+  it('passes through writes', function(done) {
+    var s1 = through.obj();
+    var s2 = through.obj();
+
+    var streams = new OrderedStreams([s1, s2]);
+    var results = [];
+    streams.on('data', function (data) {
+      results.push(data);
+    });
+    streams.on('end', function () {
+      results.length.should.be.exactly(3);
+      results[0].should.equal('stream 1');
+      results[1].should.equal('upstream');
+      results[2].should.equal('stream 2');
+      done();
+    });
+
+    s1.write('stream 1');
+    s1.end();
+
+    streams.write('upstream');
+
+    s2.write('stream 2');
+    s2.end();
+  });
+
   it('should emit all data event from each stream', function (done) {
     var s = through.obj();
 


### PR DESCRIPTION
Ref #13 

It seems that it needed to inherit from `Transform` instead of `Duplex` for the writes to be passed through successfully.

I think this actually interleaves the writes from upstream so it isn't completely ordered but I'm not sure if that can be solved.

Edit: I'm not sure if this should be considered a breaking change.  It technically changes the interface but it can still be used in the same way.

An aside: would you be open to me rewriting the tests to use patterns I've come up with for glob-stream and vinyl-fs?